### PR TITLE
Dockerfile now derives from golang:1.8.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-# Docker image for the Drone Terraform plugin
-#
-#     docker build --rm=true -t jmccann/drone-terraform:latest .
-
-FROM alpine:3.5
+FROM golang:1.8.0-alpine
 
 ENV TERRAFORM_VERSION 0.8.8
 
@@ -13,9 +9,13 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk
 	wget && \
   rm -rf /var/cache/apk/* && \
   wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
-  unzip terraform.zip && \
-  rm terraform.zip && \
-  mv terraform /bin
+  unzip terraform.zip -d /bin && \
+  rm -rf /var/cache/apk/* terraform.zip
 
-ADD drone-terraform /bin/
-ENTRYPOINT ["/bin/drone-terraform"]
+ADD . /go/src/github.com/jmccann/drone-terraform
+
+WORKDIR /go/src/github.com/jmccann/drone-terraform
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install -a -tags netgo
+
+ENTRYPOINT ["/go/bin/drone-terraform"]


### PR DESCRIPTION
With this new Docker image, we can now have the Docker images automatically built on Quay. 

This means, we can now have continuous build for this repository. 